### PR TITLE
Update .gitleaks.toml

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -99,12 +99,11 @@ title = "gitleaks config"
     description = "Google API key"
     regex = '''[\'\" ]AIza[0-9A-Za-z\-_]{35}'''
     tags = ["key", "Google"]
-	[rules.allowlist]
-		description = "Ignore Firebase config files For Apple apps"
+    [rules.allowlist]
+        description = "Ignore Firebase config files For Apple apps"
         files = [
             '''(GoogleService-Info.plist)$'''
         ]
-
 
 [[rules]]
     description = "Google (GCP) Service Account"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -99,6 +99,12 @@ title = "gitleaks config"
     description = "Google API key"
     regex = '''[\'\" ]AIza[0-9A-Za-z\-_]{35}'''
     tags = ["key", "Google"]
+	[rules.allowlist]
+		description = "Ignore Firebase config files For Apple apps"
+        files = [
+            '''(GoogleService-Info.plist)$'''
+        ]
+
 
 [[rules]]
     description = "Google (GCP) Service Account"


### PR DESCRIPTION
Allowed file as per seen in https://firebase.google.com/docs/ios/setup#add-config-file and https://firebase.google.com/docs/projects/learn-more#config-files-objects, adds non-secret identifiers for projects.