### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ case $EXIT_CODE in
 *) echo -e "Exit code was $EXIT_CODE\n\n" ;;
 esac
 
-echo "::set-output name=exit_code::$EXIT_CODE"
-echo "::set-output name=result::$(jq -c . < gitleaks.json | sed 's/\x27/`/g')"
+echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
+echo "result=$(jq -c . < gitleaks.json | sed 's/\x27/`/g')" >> $GITHUB_OUTPUT
 
 rm -rf gitleaks gitleaks.json


### PR DESCRIPTION
## Description

Replaces the usage of the command `set-output` with the new output method of GitHub Actions.

This change is requested due to the deprecation of the command `set-output` by the GHA platform.

Link: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Problem evidence

**Warnings appearing upon `Security Workflow` execution:**
![Captura de Tela 2023-02-24 às 14 27 24](https://user-images.githubusercontent.com/29106417/221247260-c7f726cd-172f-41f5-8402-f9968b59fbaf.png)

## Testing

**PR used to test the security workflow:** https://github.com/olxbr/olx-mobile/pull/2317
**Security Workflow run:** https://github.com/olxbr/olx-mobile/actions/runs/4264688909 (**no warnings showed**)

**GitLeaks step:**
![image](https://user-images.githubusercontent.com/29106417/221245820-a988a810-5c20-4604-8906-616f7255fc4f.png)